### PR TITLE
Edit: Add quotes around the media file parameter for mplayer

### DIFF
--- a/lib/mplayer-ruby/slave.rb
+++ b/lib/mplayer-ruby/slave.rb
@@ -21,7 +21,7 @@ module MPlayer
       mplayer_options = "-slave -quiet"
       mplayer_options += " -vf screenshot" if options[:screenshot]
 
-      mplayer = "#{options[:path]} #{mplayer_options} #{@file}"
+      mplayer = "#{options[:path]} #{mplayer_options} \"#{@file}\""
       @pid,@stdin,@stdout,@stderr = Open4.popen4(mplayer)
       until @stdout.gets.inspect =~ /playback/ do
       end #fast forward past mplayer's initial output


### PR DESCRIPTION
Adding quotes around the source media file enables use of file paths/names with spaces in them.
