### PR TITLE
Add option to start in fullscreen

### DIFF
--- a/lib/mplayer-ruby/slave.rb
+++ b/lib/mplayer-ruby/slave.rb
@@ -19,6 +19,7 @@ module MPlayer
       @file = file
 
       mplayer_options = "-slave -quiet"
+      mplayer_options += " -fs" if options[:fullscreen]
       mplayer_options += " -vf screenshot" if options[:screenshot]
 
       mplayer = "#{options[:path]} #{mplayer_options} \"#{@file}\""

--- a/test/slave_test.rb
+++ b/test/slave_test.rb
@@ -30,6 +30,14 @@ context "MPlayer::Player for URL" do
   asserts_topic.assigns(:stderr)
 end
 
+context "MPlayer::Player with fullscreen enabled" do
+  setup do
+    mock(Open4).popen4('mplayer -slave -quiet -fs "test/test.mp3"') { [true,true,true,true] }
+    stub(true).gets { "playback" }
+  end
+  asserts("new :fullscreen") { MPlayer::Slave.new('test/test.mp3', :fullscreen => true) }
+end
+
 context "MPlayer::Player with screenshots enabled" do
   setup do
     mock(Open4).popen4('mplayer -slave -quiet -vf screenshot "test/test.mp3"') { [true,true,true,true] }


### PR DESCRIPTION
Hi @petems 

This branch adds the option to start MPlayer in fullscreen mode

Usage is

```ruby
@player = MPlayer::Slave.new('/path/to/a/vid.mov', :fullscreen => true)
```