### PR TITLE
Enable passing arbitrary command-line options on startup

### DIFF
--- a/lib/mplayer-ruby/slave.rb
+++ b/lib/mplayer-ruby/slave.rb
@@ -40,12 +40,14 @@ module MPlayer
 
     # Command line string to invoke mplayer
     # @param [Hash] options
+    # @option options [String] :options Arbitrary command line options
     # @option options [Boolean] :screenshot Whether to enable screenshots
     # @return [String]
     def invocation(options = {})
       path = options[:path] || "mplayer"
       command = "#{path} -slave -quiet "
       command += "-vf screenshot " if options[:screenshot]
+      command += "#{options[:options]} " unless options[:options].nil?
       command += "\"#{@file}\""
       command
     end

--- a/lib/mplayer-ruby/slave.rb
+++ b/lib/mplayer-ruby/slave.rb
@@ -18,10 +18,8 @@ module MPlayer
       options[:path] ||= 'mplayer'
       @file = file
 
-      mplayer_options = "-slave -quiet"
-      mplayer_options += " -vf screenshot" if options[:screenshot]
+      mplayer = invocation(options)
 
-      mplayer = "#{options[:path]} #{mplayer_options} \"#{@file}\""
       @pid,@stdin,@stdout,@stderr = Open4.popen4(mplayer)
       until @stdout.gets.inspect =~ /playback/ do
       end #fast forward past mplayer's initial output
@@ -39,6 +37,18 @@ module MPlayer
     end
 
     private
+
+    # Command line string to invoke mplayer
+    # @param [Hash] options
+    # @option options [Boolean] :screenshot Whether to enable screenshots
+    # @return [String]
+    def invocation(options = {})
+      path = options[:path] || "mplayer"
+      command = "#{path} -slave -quiet "
+      command += "-vf screenshot " if options[:screenshot]
+      command += "\"#{@file}\""
+      command
+    end
 
     def select_cycle(command,value,match = //)
       switch = case value

--- a/test/slave_test.rb
+++ b/test/slave_test.rb
@@ -30,6 +30,14 @@ context "MPlayer::Player for URL" do
   asserts_topic.assigns(:stderr)
 end
 
+context "MPlayer::Player with arbitrary options" do
+  setup do
+    mock(Open4).popen4('mplayer -slave -quiet -something "test/test.mp3"') { [true,true,true,true] }
+    stub(true).gets { "playback" }
+  end
+  asserts("new :arbitrary") { MPlayer::Slave.new('test/test.mp3', :options => "-something") }
+end
+
 context "MPlayer::Player with screenshots enabled" do
   setup do
     mock(Open4).popen4('mplayer -slave -quiet -vf screenshot "test/test.mp3"') { [true,true,true,true] }


### PR DESCRIPTION
@petems 

This branch enables passing arbitrary command-line options to MPlayer on startup.  

Usage is:

```ruby
@player = MPlayer::Slave.new("/path/to/a/vid.mov", :options => "-vo macosx:device_id=1")
```

This branch in turn extracts the method `Slave#invocation` where the command-line to invoke MPlayer is contructed